### PR TITLE
fix: make type checking hot loader friendly

### DIFF
--- a/src/Menu/Menu.jsx
+++ b/src/Menu/Menu.jsx
@@ -17,6 +17,7 @@ MenuTrigger.defaultProps = {
   tag: 'div',
   className: null,
 };
+const MenuTriggerType = <MenuTrigger />.type;
 
 
 function MenuContent({ tag, className, ...attributes }) {
@@ -220,7 +221,7 @@ class Menu extends React.Component {
     const { className } = this.props;
 
     const wrappedChildren = React.Children.map(this.props.children, (child) => {
-      if (child.type === MenuTrigger) {
+      if (child.type === MenuTriggerType) {
         return this.renderTrigger(child);
       }
       return this.renderMenuContent(child);


### PR DESCRIPTION
react-hot-loader proxies all components so type comparisions  were
were failing in dev environment.  More details:
https://github.com/gaearon/react-hot-loader#checking-element-types