### PR TITLE
fix: make build UMD friendly

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = Merge.smart(commonConfig, {
     filename: 'main.js',
     library: 'frontend-component-site-header',
     libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
   },
   resolve: {
     extensions: ['.js', '.jsx'],


### PR DESCRIPTION
By setting globalObject, the production source shouldn't reference
`window` directly.