### PR TITLE
feat: use frontend-i18n library

### DIFF
--- a/example/src/index.jsx
+++ b/example/src/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { IntlProvider } from 'react-intl';
+import { IntlProvider } from '@edx/frontend-i18n';
 import SiteHeader from '../../src/index';
 
 import './index.scss';

--- a/example/src/index.scss
+++ b/example/src/index.scss
@@ -1,3 +1,3 @@
-@import "~@edx/edx-bootstrap/scss/edx-bootstrap";
+@import "~@edx/edx-bootstrap/scss/edx/theme.scss";
 
 @import '../../src/index.scss';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1980,6 +1980,12 @@
         "find-up": "^2.1.0"
       }
     },
+    "@cospired/i18n-iso-languages": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cospired/i18n-iso-languages/-/i18n-iso-languages-2.0.2.tgz",
+      "integrity": "sha512-APBpZvdQrC1MJWMzk33V7FR2RhBRtnH2QPLqZzS+qia7PixwgWNlnX7UfHjhx+YWkM53GdsZKs40EBkSwADuMA==",
+      "dev": true
+    },
     "@edx/edx-bootstrap": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@edx/edx-bootstrap/-/edx-bootstrap-2.2.1.tgz",
@@ -1988,6 +1994,64 @@
       "requires": {
         "bootstrap": "^4.3.1"
       }
+    },
+    "@edx/frontend-i18n": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-i18n/-/frontend-i18n-1.0.4.tgz",
+      "integrity": "sha512-SXvcfJsfjv+meApq4/teXQrgzsJcPqmp68FePmKRuEp/CgTqM128uPfcxymmjl+dx+EAHX3AKE2gzJhNeYeMRA==",
+      "dev": true,
+      "requires": {
+        "@cospired/i18n-iso-languages": "^2.0.2",
+        "glob": "^7.1.4",
+        "i18n-iso-countries": "^4.0.0",
+        "iso-countries-languages": "^0.2.1",
+        "react-intl": "^2.9.0",
+        "universal-cookie": "^4.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "react-intl": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.9.0.tgz",
+          "integrity": "sha512-27jnDlb/d2A7mSJwrbOBnUgD+rPep+abmoJE511Tf8BnoONIAUehy/U1zZCHGO17mnOwMWxqN4qC0nW11cD6rA==",
+          "dev": true,
+          "requires": {
+            "hoist-non-react-statics": "^3.3.0",
+            "intl-format-cache": "^2.0.5",
+            "intl-messageformat": "^2.1.0",
+            "intl-relativeformat": "^2.1.0",
+            "invariant": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@edx/frontend-logging": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-logging/-/frontend-logging-2.0.3.tgz",
+      "integrity": "sha512-8PnHKW+LAOjXfJEdaxxI449iCVG6SNM+4DO1n8x6BoZZEpmy9fLgvmvIhMrPjrlPNTMSlcAC78mmpYUC3rSslg==",
+      "dev": true
     },
     "@jest/console": {
       "version": "24.7.1",
@@ -3439,6 +3503,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -3491,6 +3561,12 @@
       "version": "11.10.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.5.tgz",
       "integrity": "sha512-DuIRlQbX4K+d5I+GMnv+UfnGh+ist0RdlvOp+JZ7ePJ6KQONCFQv/gKYSU1ZzbVdFSUCKZOltjmpFAGGv5MdYA==",
+      "dev": true
+    },
+    "@types/object-assign": {
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
+      "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI=",
       "dev": true
     },
     "@types/q": {
@@ -9339,12 +9415,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-      "dev": true
-    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -9926,6 +9996,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
       "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+    },
+    "i18n-iso-countries": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-4.1.0.tgz",
+      "integrity": "sha512-ttqCFBUvVSwUCgyjjIG95lilFg/61INah89ih/znBYHrZAcD5HsFUr8CJBmEgIOPbw0jZFgAPAsYRPGQexMTeA==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -10533,6 +10609,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "iso-countries-languages": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/iso-countries-languages/-/iso-countries-languages-0.2.1.tgz",
+      "integrity": "sha512-MSLwTToJmw0VS/NdCvwsgt28zE5A/rGsPpdPOrepFgAanVDBUguAgGj/73NTIrLifICz2pTmJNHZNPwDXmAMTw==",
       "dev": true
     },
     "isstream": {
@@ -17975,19 +18057,6 @@
         "scheduler": "^0.13.4"
       }
     },
-    "react-intl": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.8.0.tgz",
-      "integrity": "sha512-1cSasNkHxZOXYYhms9Q1tSEWF8AWZQNq3nPLB/j8mYV0ZTSt2DhGQXHfKrKQMu4cgj9J1Crqg7xFPICTBgzqtQ==",
-      "dev": true,
-      "requires": {
-        "hoist-non-react-statics": "^2.5.5",
-        "intl-format-cache": "^2.0.5",
-        "intl-messageformat": "^2.1.0",
-        "intl-relativeformat": "^2.1.0",
-        "invariant": "^2.1.1"
-      }
-    },
     "react-is": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
@@ -21488,6 +21557,18 @@
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
       "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
       "dev": true
+    },
+    "universal-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.0.tgz",
+      "integrity": "sha512-6JVx+3oGPjslGqFhQ8YSIBHmYTx8HbyAEH++2/b6SKNXsbsdQ7lU7wRG2bYcRB5JVCz8GYgQ+Ixew91hn3Dy9w==",
+      "dev": true,
+      "requires": {
+        "@types/cookie": "^0.3.1",
+        "@types/object-assign": "^4.0.30",
+        "cookie": "^0.3.1",
+        "object-assign": "^4.1.0"
+      }
     },
     "universal-user-agent": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "@commitlint/prompt": "^6.0.2",
     "@commitlint/prompt-cli": "^6.0.2",
     "@edx/edx-bootstrap": "^2.2.1",
+    "@edx/frontend-i18n": "^1.0.4",
+    "@edx/frontend-logging": "^2.0.3",
     "@svgr/webpack": "^4.1.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.6",
@@ -59,7 +61,6 @@
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "react-intl": "^2.8.0",
     "react-test-renderer": "^16.6.0",
     "sass-loader": "^7.1.0",
     "semantic-release": "^15.1.7",
@@ -71,6 +72,8 @@
     "webpack-merge": "^4.2.1"
   },
   "peerDependencies": {
+    "@edx/frontend-i18n": "^1.0.4",
+    "@edx/frontend-logging": "^2.0.3",
     "@edx/paragon": "^3.8.0",
     "prop-types": "^15.5.10",
     "react": "^16.4.2",

--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n';
 
 // Local Components
 import { Menu, MenuTrigger, MenuContent } from './Menu';

--- a/src/MobileHeader.jsx
+++ b/src/MobileHeader.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n';
 
 // Local Components
 import { Menu, MenuTrigger, MenuContent } from './Menu';

--- a/src/SiteHeader.messages.jsx
+++ b/src/SiteHeader.messages.jsx
@@ -1,4 +1,4 @@
-import { defineMessages } from 'react-intl';
+import { defineMessages } from '@edx/frontend-i18n';
 
 const messages = defineMessages({
   'header.label.account.nav': {

--- a/src/SiteHeader.test.jsx
+++ b/src/SiteHeader.test.jsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { IntlProvider } from 'react-intl';
+import { IntlProvider } from '@edx/frontend-i18n';
 import TestRenderer from 'react-test-renderer';
 
 import './__mocks__/reactResponsive.mock';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,14 @@ module.exports = Merge.smart(commonConfig, {
       amd: 'PropTypes',
       root: 'PropTypes',
     },
+    '@edx/frontend-i18n': {
+      commonjs: '@edx/frontend-i18n',
+      commonjs2: '@edx/frontend-i18n',
+    },
+    '@edx/frontend-logging': {
+      commonjs: '@edx/frontend-logging',
+      commonjs2: '@edx/frontend-logging',
+    },
   },
   plugins: [
     // Cleans the dist directory before each build


### PR DESCRIPTION
BREAKING CHANGE: Consumers of this header will now need to be sure to include the peer dependency: edx/frontend-i18n.