### PR TITLE
feat(skip-nav): add skip nav link to header

### DIFF
--- a/example/src/index.jsx
+++ b/example/src/index.jsx
@@ -21,6 +21,7 @@ class App extends React.Component {
       <IntlProvider>
         <div>
           <SiteHeader
+            skipNavId="content"
             logo={Logo}
             logoDestination="https://edx.org"
             logoAltText="edX"
@@ -82,7 +83,7 @@ class App extends React.Component {
               { type: 'item', href: '#', content: 'Sign Up' },
             ]}
           />
-          <main className="py-5">
+          <main id="content" className="py-5">
             <button
               className="btn btn-primary"
               onClick={() => {

--- a/src/SiteHeader.jsx
+++ b/src/SiteHeader.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Responsive from 'react-responsive';
 
 // Components
@@ -9,6 +10,11 @@ import MobileHeader from './MobileHeader';
 function SiteHeader(props) {
   return (
     <React.Fragment>
+      {props.skipNavId && (
+        <div className="position-absolute">
+          <a href={`#${props.skipNavId}`} className="skip-nav-link sr-only sr-only-focusable btn btn-primary px-2 py-1 mt-3 ml-2">Skip to main content</a>
+        </div>
+      )}
       <Responsive maxWidth={768}>
         <MobileHeader {...props} />
       </Responsive>
@@ -19,5 +25,12 @@ function SiteHeader(props) {
   );
 }
 
+SiteHeader.defaultProps = {
+  skipNavId: null,
+};
+
+SiteHeader.propTypes = {
+  skipNavId: PropTypes.string,
+};
 
 export default SiteHeader;

--- a/src/index.scss
+++ b/src/index.scss
@@ -90,3 +90,9 @@ $white: #fff;
     border-radius: $rounded-pill;
   }
 }
+
+.skip-nav-link:active, .skip-nav-link:focus {
+  position: relative;
+  z-index: 1010;
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
This PR adds a "skip to main navigation" link in the header for a11y. It adds a new prop to `SiteHeader` for the skip link ID in your consuming app. If an ID is not provided, it will not render the skip link.

The skip link only appears in the UI if you tab; otherwise it will only be accessible to screen readers.

![image](https://user-images.githubusercontent.com/2828721/59952327-c0d1a900-9449-11e9-878b-d697eacc6e72.png)
