### PR TITLE
Change MenuTrigger class for rebrand

### DIFF
--- a/src/DesktopHeader.jsx
+++ b/src/DesktopHeader.jsx
@@ -65,7 +65,7 @@ class DesktopHeader extends React.Component {
         <MenuTrigger
           tag="button"
           aria-label={intl.formatMessage(messages['header.label.account.menu.for'], { username })}
-          className="btn btn-light d-inline-flex align-items-center pl-2 pr-3"
+          className="btn btn-outline-primary d-inline-flex align-items-center pl-2 pr-3"
         >
           <Avatar size="1.5em" src={avatar} alt="" className="mr-2" />
           {username} <CaretIcon role="img" aria-hidden focusable="false" />


### PR DESCRIPTION
In order to update [frontend-app-learner-portal-programs](https://github.com/edx/frontend-app-learner-portal-programs) for the rebrand, the header should only require this minor style change. Later we can consider pulling in and refactoring the header code.

![Screen Shot 2020-11-25 at 12 00 29 PM](https://user-images.githubusercontent.com/10442143/100259107-d6d47a80-2f15-11eb-877f-a9bfb125f11f.png)
